### PR TITLE
Workaround for inverted y coordinate and updates field to compensate.

### DIFF
--- a/src/main/java/frc/robot/commands/DriveToPosition.java
+++ b/src/main/java/frc/robot/commands/DriveToPosition.java
@@ -28,7 +28,7 @@ public class DriveToPosition extends CommandBase {
     addRequirements(drive);
     m_drive = drive;
     m_x = x;
-    m_y = y;
+    m_y = -y; // negative is workaround for coordinate issue
     m_thetaDegrees = thetaDegrees;
     m_targetPose = new Pose2d(x, y, Rotation2d.fromDegrees(thetaDegrees));
   }

--- a/src/main/java/frc/robot/commands/auto/StartingPosition.java
+++ b/src/main/java/frc/robot/commands/auto/StartingPosition.java
@@ -18,7 +18,7 @@ public class StartingPosition extends BaseAutoCommand {
         super(parsedCommand);
         m_SwerveDrive = swerveDrive;
         m_x = AutoUtil.parseDouble(parsedCommand.getArgument("x"), 0.0);
-        m_y = AutoUtil.parseDouble(parsedCommand.getArgument("y"), 0.0);
+        m_y = -AutoUtil.parseDouble(parsedCommand.getArgument("y"), 0.0); // negative is workaround for coordinate issue
         m_angle = AutoUtil.parseDouble(parsedCommand.getArgument("angle"), 0.0);
     }
 

--- a/src/main/java/frc/robot/subsystems/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDrive.java
@@ -47,7 +47,7 @@ public class SwerveDrive extends SubsystemBase {
   }
 
   public Rotation2d getRotation() {
-    return Rotation2d.fromDegrees(m_gyro.getAngle());
+    return Rotation2d.fromDegrees(-m_gyro.getAngle());
 
   }
 
@@ -234,7 +234,7 @@ public class SwerveDrive extends SubsystemBase {
     //pose = pose.transformBy(new Transform2d(new Translation2d(), Rotation2d.fromDegrees(90)));
     m_field.setRobotPose(correctedPose);
     SmartDashboard.putBoolean("Gyro/Calibrating", m_gyro.isCalibrating());
-    SmartDashboard.putNumber("Gyro/Angle", m_gyro.getAngle());
+    SmartDashboard.putNumber("Gyro/Angle", getRotation().getDegrees());
 
     if (m_enableTuningPIDs) {
       tunePIDs();

--- a/src/main/java/frc/robot/subsystems/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDrive.java
@@ -66,9 +66,7 @@ public class SwerveDrive extends SubsystemBase {
 
   /** Creates a new SwerveDrive. */
   public SwerveDrive() {
-    if (RobotBase.isSimulation()) {
-      SmartDashboard.putData("Field", m_field);
-    }
+    SmartDashboard.putData("Field", m_field);
     double width = 0.2957;
     double length = 0.32067;
     m_moduleFL = new SwerveDriveModule(length, -width, SwerveModulePosition.FrontLeft.name(),
@@ -228,12 +226,13 @@ public class SwerveDrive extends SubsystemBase {
     // This method will be called once per scheduler run
     m_odometry.update(getRotation(), getModuleStates());
     Pose2d pose = getPose();
-    m_moduleFL.updatePosition(pose);
-    m_moduleFR.updatePosition(pose);
-    m_moduleBR.updatePosition(pose);
-    m_moduleBL.updatePosition(pose);
+    Pose2d correctedPose = new Pose2d(pose.getX(), -pose.getY(), pose.getRotation());
+    m_moduleFL.updatePosition(correctedPose);
+    m_moduleFR.updatePosition(correctedPose);
+    m_moduleBR.updatePosition(correctedPose);
+    m_moduleBL.updatePosition(correctedPose);
     //pose = pose.transformBy(new Transform2d(new Translation2d(), Rotation2d.fromDegrees(90)));
-    m_field.setRobotPose(pose);
+    m_field.setRobotPose(correctedPose);
     SmartDashboard.putBoolean("Gyro/Calibrating", m_gyro.isCalibrating());
     SmartDashboard.putNumber("Gyro/Angle", m_gyro.getAngle());
 

--- a/src/main/java/frc/robot/subsystems/SwerveDriveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDriveModule.java
@@ -172,6 +172,10 @@ public class SwerveDriveModule {
     }
 
     public void Stop() {
+        // Update these values to fix display issues in the simulator
+        m_targetVelocity = 0;
+        m_targetAngle = getCurrentAngleDegrees();
+
         setManual(0, 0);
     }
 


### PR DESCRIPTION
This will invert the y values for the drive commands so that they match the inverted coordinate issue with the robot. 

It also inverts the display of the field, so the robot appears on the field in the correct position on the dashboard (the simulator and actual robot positions should match now).

Also includes a small change to the stop the robot from spinning in the simulator when the robot is disabled/commands have finished. 