### PR TITLE
Adjusts the SetSpeedLauncherShoot command to allow launching with the hood up

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -71,7 +71,7 @@ public final class Constants {
     
     // Launcher Settings
     public final static double DefaultLauncherLowSpeed = 2300.0;
-    public final static double DefaultLauncherHighSpeed = 9600.0;
+    public final static double DefaultLauncherHighSpeed = 4700.0;
 
     // Target position on field
     public final static double GoalX = 8.0; // TODO: Get real values

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -149,7 +149,7 @@ public class RobotContainer {
     m_driver.getButtonLT().whileHeld(new IntakeCommand(m_feeder, m_intake));
 
     m_driver.getButtonRB()
-        .whileHeld(new SetSpeedLauncherShoot(m_launcher, m_feeder, Constants.DefaultLauncherLowSpeed));
+        .whileHeld(new SetSpeedLauncherShoot(m_launcher, m_feeder, Constants.DefaultLauncherHighSpeed, true));
     m_driver.getButtonRT()
         .whileHeld(new CameraLauncherShoot(m_launcher, m_camera, m_feeder, m_flywheelTable));
 
@@ -168,7 +168,7 @@ public class RobotContainer {
 
     m_operator.getButtonRB().whileHeld(new CameraLauncherShoot(m_launcher, m_camera, m_feeder, m_flywheelTable));
     m_operator.getButtonRT()
-        .whileHeld(new RunCommand(() -> m_launcher.SetTargetRPM(Constants.DefaultLauncherLowSpeed), m_launcher));
+        .whileHeld(new SetSpeedLauncherShoot(m_launcher, m_feeder, Constants.DefaultLauncherLowSpeed, false));
 
     m_operator.getButtonLB().whileHeld(new RunCommand(() -> m_intake.MoveIntakeUp(), m_intake));
     m_operator.getButtonLT().whileHeld(new RunCommand(() -> m_intake.MoveIntakeDown(), m_intake));

--- a/src/main/java/frc/robot/commands/BaseLauncherShoot.java
+++ b/src/main/java/frc/robot/commands/BaseLauncherShoot.java
@@ -45,7 +45,7 @@ public abstract class BaseLauncherShoot extends CommandBase {
 
   // Called once the command ends or is interrupted.
   @Override
-  public final void end(boolean interrupted) {
+  public void end(boolean interrupted) {
     m_launcher.coast();
     m_feeder.setFeederMode(FeederMode.DEFAULT);
   }

--- a/src/main/java/frc/robot/commands/SetSpeedLauncherShoot.java
+++ b/src/main/java/frc/robot/commands/SetSpeedLauncherShoot.java
@@ -13,16 +13,34 @@ import frc.robot.subsystems.Launcher;
 
 public class SetSpeedLauncherShoot extends BaseLauncherShoot {
   private double m_manualSpeed;
+  private boolean m_setHoodUp;
 
   /** Creates a new LauncherShoot. */
-  public SetSpeedLauncherShoot(Launcher launcher, Feeder feeder, double manualSpeed) {
+  public SetSpeedLauncherShoot(Launcher launcher, Feeder feeder, double manualSpeed, boolean setHoodUp) {
     super(launcher, feeder);
     m_manualSpeed = manualSpeed;
+    m_setHoodUp = setHoodUp;
+  }
+
+  @Override
+  public void initialize() {
+    super.initialize();
+    if(m_setHoodUp) {
+      m_launcher.MoveHoodUp();
+    }
   }
   
   public static SetSpeedLauncherShoot CreateAutoCommand(ParsedCommand pc, Launcher launcher, Feeder feeder) {
     var speed = AutoUtil.parseDouble(pc.getArgument("speed"), Constants.DefaultLauncherLowSpeed);
-    return new SetSpeedLauncherShoot(launcher, feeder, speed);
+    return new SetSpeedLauncherShoot(launcher, feeder, speed, false);
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    super.end(interrupted);
+    if(m_setHoodUp) {
+      m_launcher.MoveHoodDown();
+    }
   }
 
   @Override


### PR DESCRIPTION
This is the code we were trying in Classical Hall on Saturday. 

It allows the `SetSpeedLauncherShoot` command to raise the hood up, but lowers it when the command is done.