### PR TITLE
Configures the launcher to always run at a spin up speed

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -75,6 +75,8 @@ public final class Constants {
     public final static double DefaultLauncherTolerance = 300.0;
     public final static double DefaultLauncherToleranceLowBumper = 600.0;
     public final static double DefaultFeederLaunchSpeed = 0.25;
+    public final static double DefaultLauncherSpinUpTeleop = DefaultLauncherLowSpeed;
+    public final static double DefaultLauncherSpinUpAuto = 5000;
 
     // Target position on field
     public final static double GoalX = 8.0; // TODO: Get real values

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -192,6 +192,7 @@ public class RobotContainer {
    */
   public Command getAutonomousCommand() {
     // An ExampleCommand will run in autonomous
-    return m_autoBuilder.createAutoCommand();
+    var spinUpLauncherStart = new InstantCommand(() -> m_launcher.spinUpSpeed(), m_launcher);
+    return spinUpLauncherStart.andThen(m_autoBuilder.createAutoCommand());
   }
 }

--- a/src/main/java/frc/robot/commands/BaseLauncherShoot.java
+++ b/src/main/java/frc/robot/commands/BaseLauncherShoot.java
@@ -48,7 +48,7 @@ public abstract class BaseLauncherShoot extends CommandBase {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_launcher.coast();
+    m_launcher.spinUpSpeed();
     m_feeder.setFeederMode(FeederMode.DEFAULT);
   }
 

--- a/src/main/java/frc/robot/commands/DriverRelativeDriveAimAndLaunch.java
+++ b/src/main/java/frc/robot/commands/DriverRelativeDriveAimAndLaunch.java
@@ -91,7 +91,7 @@ public class DriverRelativeDriveAimAndLaunch extends BaseRelativeDrive {
   @Override
   public void end(boolean interrupted) {
     super.end(interrupted);
-    m_launcher.coast();
+    m_launcher.spinUpSpeed();
     m_feeder.setFeederMode(FeederMode.DEFAULT);
   }
 }

--- a/src/main/java/frc/robot/commands/LauncherDefault.java
+++ b/src/main/java/frc/robot/commands/LauncherDefault.java
@@ -22,12 +22,12 @@ public class LauncherDefault extends CommandBase {
   @Override
   public void initialize() {
     m_launcher.setLauncherTolerance(Constants.DefaultLauncherTolerance);
+    m_launcher.spinUpSpeed();
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    m_launcher.coast();
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/subsystems/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/Launcher.java
@@ -13,7 +13,9 @@ import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
 
 import edu.wpi.first.wpilibj.DoubleSolenoid;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.DoubleSolenoid.Value;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -70,6 +72,16 @@ public class Launcher extends SubsystemBase {
   public void SetTargetRPM(double rpm) {
     m_ControllerA.set(TalonFXControlMode.Velocity, rpm);
     m_ControllerB.set(TalonFXControlMode.Velocity, rpm);
+  }
+
+  public void spinUpSpeed() {
+    if (DriverStation.isAutonomous()) {
+      m_ControllerA.set(TalonFXControlMode.Velocity, Constants.DefaultLauncherSpinUpAuto);
+      m_ControllerB.set(TalonFXControlMode.Velocity, Constants.DefaultLauncherSpinUpAuto);
+    } else {
+      m_ControllerA.set(TalonFXControlMode.Velocity, Constants.DefaultLauncherSpinUpTeleop);
+      m_ControllerB.set(TalonFXControlMode.Velocity, Constants.DefaultLauncherSpinUpTeleop);
+    }
   }
 
   public void coast() {


### PR DESCRIPTION
This should cause the launcher to constantly run at two speeds (auto vs teleop), but still be changed for the commands that change the values.