### PR TITLE
Fixes for data reductions before DIstrict Champs

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -93,4 +93,7 @@ public final class Constants {
     public final static double HeightOfGoal = 2.6416; // 104 Inches
     public final static double RadiusOfTopGoal = 0.6858;
 
+    // CAN Frame Periods
+    public final static int MaxCANStatusFramePeriod = 255;
+
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.TimedRobot;
+import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.commands.DriverRelativeDriveWithAimSimple;
@@ -25,9 +26,10 @@ import frc.robot.logging.LoggedDatapoints;
  * project.
  */
 public class Robot extends TimedRobot {
-  public static final LogManager LogManager = new LogManager(true);
+  public static final boolean IsDebuggingMode = false;
+  public static final LogManager LogManager = new LogManager(IsDebuggingMode);
   public static final LoggedDatapoints LoggedDatapoints = new LoggedDatapoints();
-  public static final boolean EnablePIDTuning = true;
+  public static final boolean EnablePIDTuning = IsDebuggingMode;
   private final Compressor compressor = new Compressor(PneumaticsModuleType.REVPH);
   private Command m_autonomousCommand;
   private RobotContainer m_robotContainer;
@@ -53,6 +55,9 @@ public class Robot extends TimedRobot {
     LogManager.addNumber("Robot/LoopTime", () -> m_lastLoop_ms);
 
     LogManager.writeHeaders();
+
+    // Reduces data sent to the dashboard and we're not using this
+    LiveWindow.disableAllTelemetry();
   }
 
   public static double robotMode()

--- a/src/main/java/frc/robot/logging/LogManager.java
+++ b/src/main/java/frc/robot/logging/LogManager.java
@@ -66,16 +66,21 @@ public class LogManager {
     }
 
     public void update() {
-        if (m_loggingThread.getState() == Thread.State.NEW) {
-            if (DriverStation.isDSAttached()) {
-                m_loggingThread.start();
+        try {
+            if (m_loggingThread.getState() == Thread.State.NEW) {
+                if (DriverStation.isDSAttached()) {
+                    m_loggingThread.start();
+                }
+            } else {
+                StringBuilder sb = new StringBuilder();
+                for (String header : m_headers) {
+                    sb.append(m_suppliers.get(header).get() + ",");
+                }
+                m_loggingThread.enqueue(sb.toString());
             }
-        } else {
-            StringBuilder sb = new StringBuilder();
-            for (String header : m_headers) {
-                sb.append(m_suppliers.get(header).get() + ",");
-            }
-            m_loggingThread.enqueue(sb.toString());
+        } catch (Exception ex) {
+            // If logging fails, print the stack trace, but don't rethrow it
+            ex.printStackTrace();
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/Feeder.java
+++ b/src/main/java/frc/robot/subsystems/Feeder.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.InvertType;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 
@@ -34,6 +35,13 @@ public class Feeder extends SubsystemBase {
     m_lowerFeeder.configOpenloopRamp(0.2);
     m_upperFeeder.setNeutralMode(NeutralMode.Brake);
     m_lowerFeeder.setNeutralMode(NeutralMode.Brake);
+
+    // Lower CAN Utilization. We are only setting percent power to the motors, so we don't need the data
+    m_upperFeeder.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, Constants.MaxCANStatusFramePeriod);
+    m_lowerFeeder.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, Constants.MaxCANStatusFramePeriod);
+    m_upperFeeder.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, Constants.MaxCANStatusFramePeriod);
+    m_lowerFeeder.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, Constants.MaxCANStatusFramePeriod);
+
     m_beamSensorTop = new DigitalInput(Constants.FeederBeamSensorTop);
     m_beamSensorMiddle = new DigitalInput(Constants.FeederBeamSensorMiddle);
   }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 
@@ -23,6 +24,10 @@ public class Intake extends SubsystemBase {
     m_IntakeController.setNeutralMode(NeutralMode.Coast);
     m_IntakeController.configOpenloopRamp(0.4);
     m_solenoid = new DoubleSolenoid(PneumaticsModuleType.REVPH, Constants.IntakeSolenoidForward, Constants.IntakeSolenoidReverse);
+
+    // Lower CAN Utilization. We are only setting percent power to the motor, so we don't need the data
+    m_IntakeController.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, Constants.MaxCANStatusFramePeriod);
+    m_IntakeController.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, Constants.MaxCANStatusFramePeriod);
     
   }
   public void ManualIntake(double power) {

--- a/src/main/java/frc/robot/subsystems/Launcher.java
+++ b/src/main/java/frc/robot/subsystems/Launcher.java
@@ -8,6 +8,7 @@ import com.chaos131.pid.PIDTuner;
 import com.chaos131.pid.PIDUpdate;
 import com.ctre.phoenix.motorcontrol.InvertType;
 import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.StatusFrameEnhanced;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.sensors.SensorVelocityMeasPeriod;
@@ -54,6 +55,10 @@ public class Launcher extends SubsystemBase {
 
     m_ControllerA.enableVoltageCompensation(true);
     m_ControllerB.enableVoltageCompensation(true);
+
+    // Lower CAN Utilization. We are reading data off controllerA, so we can slow the rate of status updates from B
+    m_ControllerB.setStatusFramePeriod(StatusFrameEnhanced.Status_1_General, Constants.MaxCANStatusFramePeriod);
+    m_ControllerB.setStatusFramePeriod(StatusFrameEnhanced.Status_2_Feedback0, Constants.MaxCANStatusFramePeriod);
 
     double velocityP = 0.075;
     double velocityI = 0.0003;

--- a/src/main/java/frc/robot/subsystems/SwerveDriveModule.java
+++ b/src/main/java/frc/robot/subsystems/SwerveDriveModule.java
@@ -9,6 +9,7 @@ import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.TalonFXControlMode;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
 import com.ctre.phoenix.sensors.CANCoder;
+import com.ctre.phoenix.sensors.CANCoderStatusFrame;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -49,6 +50,7 @@ public class SwerveDriveModule {
         m_name = name;
         m_absoluteEncoder = new CANCoder(absoluteEncoderPort);
         m_absoluteAngleOffset = absoluteAngleOffset;
+        m_absoluteEncoder.setStatusFramePeriod(CANCoderStatusFrame.SensorData, Constants.MaxCANStatusFramePeriod);
         var absoluteEncoderAngle = GetAbsoluteEncoderAngle();
         var angleTicksOffset = this.DegreesToFalconAngle(absoluteEncoderAngle);
         m_angleController.setSelectedSensorPosition(angleTicksOffset);


### PR DESCRIPTION
This accomplishes a few things:

- It handles errors from the LogManager better
- It disables extra NetworkTables traffic
- It reduces the CAN status frame updates for certain devices
  - Slows the rate of the cancoder status updates after we have gotten the initial angle configured
  - Slows the rate of TalonFx status updates for devices where we are not reading the encoders from (either follower motors or Feeder/Intake where we are only doing percent output)
    - [ ] Need to confirm that the motors still behave the same way
  
  
I used this as a guide for the CAN updates:

https://docs.ctre-phoenix.com/en/stable/ch18_CommonAPI.html#typical-device-utilization

![image](https://user-images.githubusercontent.com/6991773/163098897-7e25a56e-4ccc-46a3-a423-4c860dba1114.png)

We have 14 TalonFXs and 4 CANcoders:

14 * 4.6 + 4 * 1.8 = **71.6 CAN Device Utilization**

![image](https://user-images.githubusercontent.com/6991773/163099594-fbff34ad-5932-43cd-8def-8ec270e4d7ac.png)

Which explains why our CAN Utilization is roughly always above 71.6%
